### PR TITLE
docs: fix contradictions and misinformation across template docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Key architecture:
 
 - Template files use `.jinja` extension and contain variables like `{{github_repo_name}}`, `{{author_full_name}}`, etc.
 - Template variables are defined in `copier.yml`
-- The `example/` directory shows a rendered example using `.example-input.yml` as answers
+- The `example/` directory is a gitignored, locally-generated rendering (see `.gitignore`); regenerate it from `.example-input.yml` to smoke-test the template. Note: `.example-input.yml` disables every optional component, so the run commands below for CLI/web/etc. apply only after enabling those options (or to any other generated project)
 - Generated projects use uv for dependency management, hatchling for builds, tox for testing, and include full CI/CD automation
 
 ## Development Commands
@@ -232,7 +232,7 @@ The `.devcontainer/docker-compose.yml.jinja` consolidates all services:
    (see [ADR-002](../docs/adr/002-release-please-for-release-automation.md)). Jobs:
    - `release-please`: opens/maintains a release PR from Conventional Commits on
      push to `main`; on merge, tags the commit and creates a **draft** GitHub
-     Release (`draft: true` in `release-please-config.json`). Exposes
+     Release (`draft: true` in `.github/release-please-config.json`). Exposes
      `release_created`, `tag_name`, `version` as outputs.
    - All later jobs gate on `needs.release-please.outputs.release_created == 'true'`.
    - `build`: builds with uv. When `include_c_extensions` is set, runs as a
@@ -283,7 +283,7 @@ section, including ready-to-run `gh repo edit` / `gh api` commands and the PyPI
 trusted-publishing registration — keep that section in sync when these
 requirements change.
 
-Bump rules follow `release-please-config.json`: `feat` → minor, `fix`/`perf` →
+Bump rules follow `.github/release-please-config.json`: `feat` → minor, `fix`/`perf` →
 patch, `feat!`/`BREAKING CHANGE` → major — but `bump-minor-pre-major: true`
 keeps breaking changes at a minor bump while pre-1.0.
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,7 +14,7 @@ Performed a comprehensive analysis of the copier-pyproject template to understan
 
 - The template generates modern Python packages with 30+ configurable options
 - Supports 7 optional components: CLI (Typer), Web (FastAPI/Litestar), GUI (Tkinter), TUI (Textual), MCP server, Worker (FastStream), C Extensions (Cython)
-- Includes 13 linting/formatting tools, 99% coverage requirement, and multi-platform CI
+- Includes 11 linting/formatting tools, 99% coverage requirement, and multi-platform CI
 - CD workflow supports PyPI trusted publishing, Docker Hub + GHCR, PyCrucible executables
 - 130 template files using Jinja2 with conditional file inclusion
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,14 @@ Enable PyPI once per project for `.github/workflows/release-please.yml`:
 7. Set `Environment name` to `publish` (or your chosen env).
 8. Save.
 
-### Docker Hub setup (if `include_web` is enabled)
+### Container image publishing (if `include_web` is enabled)
 
-Enable Docker Hub publishing (integrated in `.github/workflows/release-please.yml`):
+On release, the workflow always publishes multi-arch images (amd64/arm64) to the
+GitHub Container Registry (`ghcr.io/<owner>/<repo>`) using the built-in
+`GITHUB_TOKEN` — no extra setup required.
+
+Docker Hub publishing is optional and runs only when the `DOCKERHUB_USERNAME`
+secret is set (integrated in `.github/workflows/release-please.yml`):
 
 1. Create a [Docker Hub Access Token](https://hub.docker.com/settings/security).
 2. In your GitHub repository, go to Settings → Secrets and variables → Actions.

--- a/docs/adr/002-release-please-for-release-automation.md
+++ b/docs/adr/002-release-please-for-release-automation.md
@@ -85,7 +85,7 @@ release-please should be wired:
 
 - The `release_automation` variable is removed from `copier.yml`; the release-it
   and release-drafter config + workflow files are deleted; the three release-please
-  files (`release-please-config.json`, `.release-please-manifest.json`,
+  files (`.github/release-please-config.json`, `.github/release-please-manifest.json`,
   `.github/workflows/release-please.yml`) become unconditional.
 - Generated projects now always include a release-please pipeline. The previous
   `none` escape hatch is gone — projects that want no automation must delete the
@@ -99,9 +99,13 @@ release-please should be wired:
   `build-executables` (PyCrucible) / `docker-publish` (web) → `attach-github-release`
   → `finalize-release`. All post-`release-please` jobs gate on
   `release_created == 'true'`. The release is created `draft: true`, artifacts are
-  attached to the draft, and `finalize-release` un-drafts it (firing
-  `release: published`, which `gh-pages.yml` still consumes) and reconciles the
-  phantom next-release PR (close + bounded re-dispatch).
+  attached to the draft, and `finalize-release` un-drafts it and reconciles the
+  phantom next-release PR (close + bounded re-dispatch). Docs deployment is the
+  `deploy-docs` job (`needs: finalize-release`) inside this same workflow, which
+  runs `mkdocs gh-deploy` — it lives here rather than reacting to
+  `release: published` because an event fired by `finalize-release`'s
+  `GITHUB_TOKEN` cannot trigger a separate workflow. `gh-pages.yml` is retained
+  only for manual `workflow_dispatch` redeploys.
 - **Trusted publishing entry workflow changed.** Because the PyPI publish step is
   inline in `release-please.yml` (not a reusable `cd.yml`), the PyPI Trusted
   Publisher must register `release-please.yml` as the workflow filename. README and

--- a/template/CHANGELOG.md.jinja
+++ b/template/CHANGELOG.md.jinja
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- refs -->
 
-[unreleased]: https://github.com/{{github_user}}/{{github_repo_name}}/compare/...0.1.0
+[unreleased]: https://github.com/{{github_user}}/{{github_repo_name}}/commits/HEAD
 
 <!-- changelog-end -->
 {%- else %}

--- a/template/docs/installation.md.jinja
+++ b/template/docs/installation.md.jinja
@@ -3,7 +3,9 @@
 > Possible extras:
 {% if include_cli %}> - cli: Installs typer and adds {{github_repo_name}} as a command.{% endif %}
 {% if include_tui %}> - tui: Installs textual and adds {{github_repo_name}}-tui as a command.{% endif %}
-{% if include_web %}> - web: Installs FastAPI and adds {{github_repo_name}}-web as a command.{% endif %}
+{% if include_web %}> - web: Installs {% if web_framework == "litestar" %}Litestar{% else %}FastAPI{% endif %} and adds {{github_repo_name}}-web as a command.{% endif %}
+{% if include_mcp %}> - mcp: Installs the MCP SDK and adds {{github_repo_name}}-mcp as a command.{% endif %}
+{% if include_worker %}> - worker: Installs FastStream and adds {{github_repo_name}}-worker as a command.{% endif %}
 {% if include_pydantic_settings %}> - config: Installs pydantic-settings.{% endif %}
 > - all: Installs all extras if available.
 


### PR DESCRIPTION
## Summary

Codebase-wide audit targeting **contradictions and misinformation** between documentation and the actual template. All findings are docs-vs-code mismatches; the template code/config itself was verified internally consistent.

## Fixes

| Severity | Finding | Fix |
|---|---|---|
| Critical | `CLAUDE.md` implied `example/` is a committed dir | Clarified it's gitignored & locally generated; noted `.example-input.yml` disables all optional components |
| Critical | ADR-002 claimed `gh-pages.yml` consumes `release: published` (it's `workflow_dispatch`-only) | Rewrote to describe the real `deploy-docs` job in `release-please.yml` |
| Important | installation.md said web extra installs "FastAPI" even for Litestar | Branches on `web_framework` |
| Important | `mcp`/`worker` extras missing from installation.md | Added, conditionally guarded |
| Important | Wrong manifest filename/paths in ADR-002 | Corrected to `.github/release-please-{config,manifest}.json` |
| Important | Bare `release-please-config.json` path in CLAUDE.md | Qualified to `.github/` |
| Minor | README documented only Docker Hub (GHCR push is unconditional) | Added GHCR section |
| Minor | Malformed `[unreleased]` changelog compare link | Replaced with valid `/commits/HEAD` |
| Minor | JOURNAL "13 linting tools" (actual: 11) | Corrected count |

## Verification

Rendered the template with `include_web=true web_framework=litestar include_mcp=true include_worker=true include_changelog=true` and confirmed installation.md and CHANGELOG.md output correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)