### PR TITLE
feat(template): enforce linked issues on pull requests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,6 +281,12 @@ The `.devcontainer/docker-compose.yml.jinja` consolidates all services:
 3. **PR title linting** (`check-pr-title.yml`): validates the **PR title** (not
    individual commits) against Conventional Commits via
    `amannn/action-semantic-pull-request`.
+4. **Linked-issue check** (`check-linked-issues.yml`): fails a PR that has no
+   linked issue (the GitHub *Development* relationship, created by a `Closes #N`
+   keyword in the PR body) via `nearform-actions/github-action-check-linked-issues`.
+   It checks the real `closingIssuesReferences` relationship, not just body text;
+   apply the `no-issue` label to bypass the check. Keep it as a required status
+   check alongside `check-pr-title`.
 
 ### Required Merge Strategy (release-please depends on it)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Copier template for a modern, typed Python package/CLI with `uv`, `hatch`, `tox`
 - Optional components: Typer CLI entrypoint, FastAPI web app, Textual TUI, Tkinter GUI, C extensions via Cython with multi-platform wheel building, profiling tools (py-spy, scalene, cProfile), logging/config modules, type hints, and a `py.typed` marker plus corresponding tests; container-ready `Dockerfile`.
 - QA stack: pytest with coverage/xdist/reruns (and `.github/codecov.yml`), ruff, mypy, basedpyright, ty, pyrefly, zuban, vulture, slotscheck, taplo, validate-pyproject, typos, actionlint.
 - Docs and site: MkDocs scaffold (`docs/index.md`) with GitHub Pages deploy workflow.
-- Automation and hygiene: CI/CD workflows (matrix tests, trusted-publishing to PyPI, gh-pages), release automation via release-please, PR title linting, issue/PR templates, `SECURITY.md` policy, `CODEOWNERS`, dependency management (Renovate), always-on Commitizen and git hooks (run via prek), always-on `CITATION.cff` with a validation workflow, devcontainer, VS Code launch config, gitignore, FUNDING, and LICENSE.
+- Automation and hygiene: CI/CD workflows (matrix tests, trusted-publishing to PyPI, gh-pages), release automation via release-please, PR title linting, linked-issue enforcement, issue/PR templates, `SECURITY.md` policy, `CODEOWNERS`, dependency management (Renovate), always-on Commitizen and git hooks (run via prek), always-on `CITATION.cff` with a validation workflow, devcontainer, VS Code launch config, gitignore, FUNDING, and LICENSE.
 - Extra tooling: `.dockerignore`, badge-rich README template, and enhanced VS Code launch.json for debugging (current file, tests, attach, entry points).
 
 ## Inputs

--- a/template/.github/workflows/check-linked-issues.yml
+++ b/template/.github/workflows/check-linked-issues.yml
@@ -1,0 +1,17 @@
+---
+name: Check Linked Issues
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+jobs:
+  check-linked-issues:
+    name: Verify linked issue
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: write
+    steps:
+      - name: Check for a linked issue
+        uses: nearform-actions/github-action-check-linked-issues@7140e2e01aa0c18b8ac61bddf5e89abde1ca760e  # v1.8.3
+        id: check_linked_issues
+        # Pass the `no-issue` label to a pull request to bypass this check.

--- a/template/CONTRIBUTING.md.jinja
+++ b/template/CONTRIBUTING.md.jinja
@@ -176,6 +176,10 @@ review before merge. Create a branch, push it, and open a PR.
 ### Pull Requests
 
 - Open the PR against `main` with a Conventional Commits **title**.
+- Link an issue in the PR body with a closing keyword (e.g. `Closes #123`) so the
+  GitHub *Development* relationship is created. The `Check Linked Issues` workflow
+  blocks PRs that have no linked issue; if a PR genuinely needs none, add the
+  `no-issue` label to bypass the check.
 - PRs are merged with **"Squash and merge"**; the squash commit message is the
   PR title. This keeps `main` history one-commit-per-PR and lets release-please
   compute the next version and changelog deterministically.
@@ -236,7 +240,29 @@ can no longer be moved or overwritten, which protects the integrity of what gets
 distributed. Enable it under **Settings → General → ... → Enable release
 immutability** (currently a UI-only toggle).
 
-**4. PyPI trusted publishing.** The release workflow publishes to PyPI via
+**4. Require the PR checks.** Protect `main` so a PR cannot merge until both the
+PR-title lint and the linked-issue check pass:
+
+```sh
+gh api -X PUT repos/{{github_user}}/{{github_repo_name}}/branches/main/protection \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["Validate PR title", "Verify linked issue"]
+  },
+  "enforce_admins": null,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+JSON
+```
+
+(UI: **Settings → Branches → Add branch ruleset / protection rule** for `main` —
+enable **Require status checks to pass** and select **Validate PR title** and
+**Verify linked issue**.)
+
+**5. PyPI trusted publishing.** The release workflow publishes to PyPI via
 [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC — no API
 tokens or secrets to manage). Register the publisher once at
 [PyPI → Publishing](https://pypi.org/manage/account/publishing/) under


### PR DESCRIPTION
## Summary

Adds an always-on `check-linked-issues.yml` workflow to generated projects using [`nearform-actions/github-action-check-linked-issues`](https://github.com/nearform-actions/github-action-check-linked-issues). It fails any PR that has no linked issue — the GitHub *Development* relationship created by a `Closes #N` keyword in the PR body.

Why this action over alternatives:
- It validates the real `closingIssuesReferences` GraphQL relationship (the Development panel), not just a regex match on body text — so it can't be fooled by a stray `#48` mention.
- Actively maintained (v1.8.3, Jun 2025), SHA-pinned (`@7140e2e… # v1.8.3`) so Renovate's native github-actions manager keeps it current.
- A `no-issue` label bypasses the check for PRs that genuinely need none.

`kentaro-m/task-completed-checker-action` was considered and rejected — it only checks markdown checkboxes, not issue links, and is unmaintained (last release 2023).

## Changes

- **New** `template/.github/workflows/check-linked-issues.yml` (plain `.yml`, no Jinja vars — mirrors `check-pr-title.yml`; `pull_request_target` with `issues: read` + `pull-requests: write`).
- `CLAUDE.md` — documents the workflow as CI/CD item #4.
- `README.md` — adds "linked-issue enforcement" to the automation list.
- `template/CONTRIBUTING.md.jinja` — issue-linking requirement in Pull Requests, plus a one-time branch-protection setup step (`gh api` PUT) requiring both `Validate PR title` and `Verify linked issue` on `main`.

## Testing

- `example/` regenerated from `.example-input.yml`.
- `tox -e style` → **OK** (all 15 commands, incl. `actionlint` over the new workflow and `typos` over the new docs).