### PR TITLE
feat(template): add PR task-list completion check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,13 @@ The `.devcontainer/docker-compose.yml.jinja` consolidates all services:
    It checks the real `closingIssuesReferences` relationship, not just body text;
    apply the `no-issue` label to bypass the check. Keep it as a required status
    check alongside `check-pr-title`.
+5. **PR task-list completion check** (`task-completed-check.yml`): on
+   `pull_request_target` (`opened`/`edited`), runs
+   `kentaro-m/task-completed-checker-action` to post a check run that fails while
+   any task-list checkbox in the PR description is unticked. Uses
+   `pull_request_target` (least-privilege `checks: write` + `pull-requests: read`)
+   so the check also runs on fork PRs; wrap throwaway lists in
+   `<!-- ignore-task-list-start -->` / `<!-- ignore-task-list-end -->` to skip them.
 
 ### Required Merge Strategy (release-please depends on it)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Copier template for a modern, typed Python package/CLI with `uv`, `hatch`, `tox`
 - Optional components: Typer CLI entrypoint, FastAPI web app, Textual TUI, Tkinter GUI, C extensions via Cython with multi-platform wheel building, profiling tools (py-spy, scalene, cProfile), logging/config modules, type hints, and a `py.typed` marker plus corresponding tests; container-ready `Dockerfile`.
 - QA stack: pytest with coverage/xdist/reruns (and `.github/codecov.yml`), ruff, mypy, basedpyright, ty, pyrefly, zuban, vulture, slotscheck, taplo, validate-pyproject, typos, actionlint.
 - Docs and site: MkDocs scaffold (`docs/index.md`) with GitHub Pages deploy workflow.
-- Automation and hygiene: CI/CD workflows (matrix tests, trusted-publishing to PyPI, gh-pages), release automation via release-please, PR title linting, linked-issue enforcement, issue/PR templates, `SECURITY.md` policy, `CODEOWNERS`, dependency management (Renovate), always-on Commitizen and git hooks (run via prek), always-on `CITATION.cff` with a validation workflow, devcontainer, VS Code launch config, gitignore, FUNDING, and LICENSE.
+- Automation and hygiene: CI/CD workflows (matrix tests, trusted-publishing to PyPI, gh-pages), release automation via release-please, PR title linting, linked-issue enforcement, PR task-list completion check, issue/PR templates, `SECURITY.md` policy, `CODEOWNERS`, dependency management (Renovate), always-on Commitizen and git hooks (run via prek), always-on `CITATION.cff` with a validation workflow, devcontainer, VS Code launch config, gitignore, FUNDING, and LICENSE.
 - Extra tooling: `.dockerignore`, badge-rich README template, and enhanced VS Code launch.json for debugging (current file, tests, attach, entry points).
 
 ## Inputs

--- a/template/.github/pull_request_template.md
+++ b/template/.github/pull_request_template.md
@@ -13,10 +13,13 @@
 ## Types of changes
 
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+<!--- This list is categorical, not a completion checklist, so it is excluded from the Task Completed Check. -->
 
+<!-- ignore-task-list-start -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
+<!-- ignore-task-list-end -->
 
 ## Usage examples
 

--- a/template/.github/workflows/task-completed-check.yml
+++ b/template/.github/workflows/task-completed-check.yml
@@ -1,0 +1,17 @@
+---
+name: Task Completed Check
+on:
+  pull_request_target:
+    types: [opened, edited]
+jobs:
+  task-check:
+    name: Check PR task list
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: read
+    steps:
+      - name: Check completed tasks
+        uses: kentaro-m/task-completed-checker-action@2ddb65fdd5577bae4a8e82e0564e459677aec893  # v0.1.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/template/.github/workflows/task-completed-check.yml
+++ b/template/.github/workflows/task-completed-check.yml
@@ -2,7 +2,7 @@
 name: Task Completed Check
 on:
   pull_request_target:
-    types: [opened, edited]
+    types: [opened, edited, synchronize, reopened]
 jobs:
   task-check:
     name: Check PR task list

--- a/template/CONTRIBUTING.md.jinja
+++ b/template/CONTRIBUTING.md.jinja
@@ -222,7 +222,38 @@ disable merge commits and rebase merging, set the squash **"Default commit
 message"** to **"Pull request title"**, and enable **Automatically delete head
 branches**.)
 
-**2. Let Actions open the release PR.** release-please runs as a GitHub Action
+**2. Required status checks.** Protect `main` so a PR can only merge once its
+checks pass. Mark these check contexts as required (the names are the **check
+runs**, not the workflow files):
+
+- `Validate PR title` — the Conventional Commits PR-title lint
+  (`check-pr-title.yml`), which release-please depends on.
+- `Verify linked issue` — the linked-issue check (`check-linked-issues.yml`),
+  which fails a PR with no linked issue.
+- `Task Completed Checker` — the PR task-list gate (`task-completed-check.yml`),
+  which fails while any unticked checkbox remains in the PR description.
+
+```sh
+gh api -X PUT repos/{{github_user}}/{{github_repo_name}}/branches/main/protection \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["Validate PR title", "Verify linked issue", "Task Completed Checker"]
+  },
+  "enforce_admins": null,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+JSON
+```
+
+(UI: **Settings → Branches → Add branch ruleset** (or **Add rule** for `main`) —
+enable **Require status checks to pass before merging**, then search for and add
+the three contexts above. The contexts only appear in the picker after each check
+has run at least once.)
+
+**3. Let Actions open the release PR.** release-please runs as a GitHub Action
 and opens/maintains the release pull request, so the repo must allow Actions to
 create and approve pull requests:
 
@@ -235,32 +266,10 @@ gh api -X PUT repos/{{github_user}}/{{github_repo_name}}/actions/permissions/wor
 (UI: **Settings → Actions → General → Workflow permissions** — enable **Allow
 GitHub Actions to create and approve pull requests**.)
 
-**3. Enable release immutability.** Once published, a release's tag and assets
+**4. Enable release immutability.** Once published, a release's tag and assets
 can no longer be moved or overwritten, which protects the integrity of what gets
 distributed. Enable it under **Settings → General → ... → Enable release
 immutability** (currently a UI-only toggle).
-
-**4. Require the PR checks.** Protect `main` so a PR cannot merge until both the
-PR-title lint and the linked-issue check pass:
-
-```sh
-gh api -X PUT repos/{{github_user}}/{{github_repo_name}}/branches/main/protection \
-  --input - <<'JSON'
-{
-  "required_status_checks": {
-    "strict": true,
-    "contexts": ["Validate PR title", "Verify linked issue"]
-  },
-  "enforce_admins": null,
-  "required_pull_request_reviews": null,
-  "restrictions": null
-}
-JSON
-```
-
-(UI: **Settings → Branches → Add branch ruleset / protection rule** for `main` —
-enable **Require status checks to pass** and select **Validate PR title** and
-**Verify linked issue**.)
 
 **5. PyPI trusted publishing.** The release workflow publishes to PyPI via
 [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC — no API


### PR DESCRIPTION
## Description

Adopts [`kentaro-m/task-completed-checker-action`](https://github.com/kentaro-m/task-completed-checker-action) into the template so every generated project ships a check that fails while any task-list checkbox in a PR description remains unticked.

## Changes

- **`template/.github/workflows/task-completed-check.yml`** — new workflow on `pull_request_target` (`opened`/`edited`), SHA-pinned action (`@2ddb65f # v0.1.2`), least-privilege `checks: write` + `pull-requests: read` so it also runs on fork PRs.
- **`template/.github/pull_request_template.md`** — wrapped the categorical "Types of changes" list in `<!-- ignore-task-list-start/end -->` so only the genuine pre-review checklist gates the PR (otherwise every PR would fail on the intentionally-unticked categorical boxes).
- **`template/CONTRIBUTING.md.jinja`** — new "Required status checks" setup step listing the `Validate PR title` and `Task Completed Checker` check-run contexts; renumbered the following steps.
- **`README.md` / `CLAUDE.md`** — documented the new check.

## Verification

- `actionlint` passes on the workflow.
- Regenerated `example/` (gitignored): the static workflow renders byte-identical, the PR template carries the ignore markers, and CONTRIBUTING renumbers cleanly 1–5.