### PR TITLE
feat(template): enforce conventional branch names on pull requests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,22 @@ The `.devcontainer/docker-compose.yml.jinja` consolidates all services:
    It checks the real `closingIssuesReferences` relationship, not just body text;
    apply the `no-issue` label to bypass the check. Keep it as a required status
    check alongside `check-pr-title`.
+5. **Branch-name linting** (`check-branch-name.yml`): validates the PR's **head
+   branch name** (`github.head_ref`) against the
+   [Conventional Branch](https://conventionalbranch.org/) format
+   (`<type>/<description>`). Allowed prefixes are exactly the spec's set —
+   `feature`/`feat`, `bugfix`/`fix`, `hotfix`, `release`, `chore`, plus the
+   AI-agent prefixes `ai`/`copilot`/`cursor`/`claude`/`codex` — **not** the
+   broader Conventional Commits type set (`docs`, `style`, `refactor`, etc. are
+   commit types, not branch types). It is a dependency-free inline shell regex (no marketplace action — the
+   maintained options were either abandoned or on a deprecated Node runtime), run
+   under `pull_request_target` with `pull-requests: write` so it can post a sticky
+   failure comment on fork PRs, mirroring `check-pr-title.yml`. The `renovate/*`
+   and `release-please--*` automation branches are whitelisted so bot PRs are
+   never blocked. Branch names never reach `main` (squash-merge uses the PR
+   title), so this is repo hygiene — not load-bearing for release-please. Keep it
+   as a required status check (context: **Validate branch name**) alongside
+   `check-pr-title` and `check-linked-issues`.
 
 ### Required Merge Strategy (release-please depends on it)
 

--- a/template/.github/workflows/check-branch-name.yml
+++ b/template/.github/workflows/check-branch-name.yml
@@ -1,0 +1,65 @@
+---
+name: Lint branch name
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+jobs:
+  main:
+    name: Validate branch name
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Lint branch name
+        id: lint_branch_name
+        env:
+          # github.head_ref is the PR's source branch. Read it through env (not
+          # inline ${{ }}) so an attacker-controlled fork branch name cannot be
+          # injected into the shell — this is why pull_request_target is safe
+          # here: we never check out or execute the PR's code.
+          BRANCH_NAME: ${{ github.head_ref }}
+        run: |
+          # Conventional Branch (https://conventionalbranch.org/): a type prefix
+          # followed by a short description. Purpose prefixes (long or short
+          # form) and AI-agent prefixes are exactly the set the spec defines.
+          # renovate/* and release-please--* are whitelisted so the automated
+          # dependency and release PRs are never blocked by this check.
+          purpose='feature|feat|bugfix|fix|hotfix|release|chore'
+          agents='ai|copilot|cursor|claude|codex'
+          # Description: lowercase alphanumerics with single '-' or '.' separators,
+          # never leading, trailing, or consecutive (per the spec's naming rules).
+          desc='[a-z0-9]+([.-][a-z0-9]+)*'
+          pattern="^(renovate/.+|release-please--.+|(${purpose}|${agents})/${desc})$"
+          if [[ "${BRANCH_NAME}" =~ ${pattern} ]]; then
+            echo "Branch \"${BRANCH_NAME}\" follows the Conventional Branch format."
+          else
+            {
+              echo "error_message=Branch \"${BRANCH_NAME}\" must follow the" \
+                "Conventional Branch format \`<type>/<description>\`" \
+                "(e.g. \`feat/add-login\`). Allowed types: ${purpose//|/, }" \
+                "(and AI-agent prefixes: ${agents//|/, })."
+            } >> "${GITHUB_OUTPUT}"
+            exit 1
+          fi
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
+        # When the previous step fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_branch_name.outputs.error_message != null)
+        with:
+          header: branch-name-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require branch names to follow the [Conventional Branch](https://conventional-branch.github.io/) specification and it looks like your branch name needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_branch_name.outputs.error_message }}
+            ```
+      # Delete a previous comment when the branch name has been fixed.
+      - if: ${{ steps.lint_branch_name.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
+        with:
+          header: branch-name-lint-error
+          delete: true

--- a/template/CONTRIBUTING.md.jinja
+++ b/template/CONTRIBUTING.md.jinja
@@ -163,11 +163,17 @@ on `main`. Please format contributions accordingly:
 
 ### Branch Names
 
-Name branches with the [Conventional Branch](https://conventional-branch.github.io/)
-format — a type prefix followed by a short, kebab-case description:
+Name branches with the [Conventional Branch](https://conventionalbranch.org/)
+format — a type prefix followed by a short, lowercase description:
 
-- `feat/add-config-loader`, `fix/login-timeout`, `docs/update-readme`,
-  `chore/bump-deps`, `refactor/extract-client`
+- `feat/add-config-loader`, `fix/login-timeout`, `chore/bump-deps`,
+  `release/2-0-0`, `claude/refactor-client`
+
+The `Lint branch name` workflow enforces this on every pull request (the
+automated `renovate/*` and `release-please--*` branches are exempt). Allowed
+prefixes are exactly those the spec defines: `feature`/`feat`, `bugfix`/`fix`,
+`hotfix`, `release`, `chore`, plus the AI-agent prefixes `ai`, `copilot`,
+`cursor`, `claude`, `codex`.
 
 Never commit directly to `main` (or `master`). `main` is integration-only:
 every change lands through a pull request so it gets CI, the PR-title lint, and
@@ -240,8 +246,8 @@ can no longer be moved or overwritten, which protects the integrity of what gets
 distributed. Enable it under **Settings → General → ... → Enable release
 immutability** (currently a UI-only toggle).
 
-**4. Require the PR checks.** Protect `main` so a PR cannot merge until both the
-PR-title lint and the linked-issue check pass:
+**4. Require the PR checks.** Protect `main` so a PR cannot merge until the
+PR-title lint, the branch-name lint, and the linked-issue check pass:
 
 ```sh
 gh api -X PUT repos/{{github_user}}/{{github_repo_name}}/branches/main/protection \
@@ -249,7 +255,7 @@ gh api -X PUT repos/{{github_user}}/{{github_repo_name}}/branches/main/protectio
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["Validate PR title", "Verify linked issue"]
+    "contexts": ["Validate PR title", "Validate branch name", "Verify linked issue"]
   },
   "enforce_admins": null,
   "required_pull_request_reviews": null,
@@ -259,8 +265,8 @@ JSON
 ```
 
 (UI: **Settings → Branches → Add branch ruleset / protection rule** for `main` —
-enable **Require status checks to pass** and select **Validate PR title** and
-**Verify linked issue**.)
+enable **Require status checks to pass** and select **Validate PR title**,
+**Validate branch name**, and **Verify linked issue**.)
 
 **5. PyPI trusted publishing.** The release workflow publishes to PyPI via
 [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC — no API


### PR DESCRIPTION
## Summary

Adds a `Lint branch name` workflow (`template/.github/workflows/check-branch-name.yml`) that validates the PR head branch name against the [Conventional Branch](https://conventionalbranch.org/) specification — mirroring the existing `check-pr-title.yml` pattern.

- **Dependency-free inline shell regex** — no marketplace action (the maintained options were either abandoned or on a deprecated Node runtime, so nothing for Renovate to track or break on Node sunsets).
- Runs under `pull_request_target` with `pull-requests: write` so it can post a **sticky failure comment** on fork PRs, with a matching delete-on-fix step.
- Allowed prefixes are exactly the spec set: `feature`/`feat`, `bugfix`/`fix`, `hotfix`, `release`, `chore`, plus the AI-agent prefixes `ai`/`copilot`/`cursor`/`claude`/`codex` — **not** the broader Conventional Commits type set.
- Strict description rules (lowercase alphanumerics, single `-`/`.` separators, no leading/trailing/consecutive separators).
- `renovate/*` and `release-please--*` automation branches are whitelisted so bot PRs are never blocked.

## Docs

- `CONTRIBUTING.md.jinja`: branch-name section notes enforcement, examples corrected to spec-valid prefixes, and `Validate branch name` added to the required status checks (CLI + UI).
- `CLAUDE.md`: documented as CI/CD workflow #5, including the Conventional Commits vs. Conventional Branch distinction.

## Notes

Branch names never reach `main` (squash-merge uses the PR title), so this is repo hygiene — not load-bearing for release-please. `docs/` and `refactor/` branches now fail since they are commit types, not branch types.

## Validation

- `actionlint` clean; `yamllint` clean (one cosmetic long-line warning matching the sibling workflow).
- Regex verified against valid/invalid/bot branch samples.