### PR TITLE
feat(template): add package_keywords prompt for custom PyPI keywords

### DIFF
--- a/.example-input.yml
+++ b/.example-input.yml
@@ -4,6 +4,7 @@ github_repo_name: example
 author_full_name: Hasan Sezer Taşan
 author_email: hasansezertasan@gmail.com
 short_description: A Python project example.
+package_keywords: "example, demo"
 include_cli: false
 include_web: false
 web_framework: fastapi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,14 @@ Required inputs:
 
 - `github_user`, `github_repo_name`, `author_full_name`, `author_email`, `short_description`
 
+Free-form metadata:
+
+- `package_keywords` - extra comma-separated PyPI keywords prepended to the generated
+  `keywords` list (default empty); the template's own base keywords plus tooling and
+  enabled-component keywords are always appended automatically. (The classifiers list
+  is still auto-generated from enabled components — it carries a `TODO` marker for the
+  generated project's author to fill in project-specific classifiers.)
+
 Optional components (all boolean):
 
 - `include_cli` - Typer CLI

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Copier will prompt for:
 - `author_full_name`
 - `author_email`
 - `short_description`
+- `package_keywords` (extra comma-separated PyPI keywords; tooling/component keywords are added automatically)
 - `include_cli` (include Typer CLI)
 - `include_web` (include web API)
 - `web_framework` (fastapi/litestar - when `include_web` is enabled)

--- a/copier.yml
+++ b/copier.yml
@@ -22,6 +22,12 @@ short_description:
   type: str
   default: A Python project template.
   help: A short description of the project
+package_keywords:
+  type: str
+  default: ""
+  help: >-
+    Extra PyPI keywords specific to your project (comma-separated, e.g.
+    "data, async, etl"). Tooling and component keywords are added automatically.
 include_cli:
   type: bool
   default: true

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -10,8 +10,8 @@ maintainers = [
   { name = "{{author_full_name}}", email = "{{author_email}}" },
 ]
 dynamic = ["version"]
-# TODO @{{github_user}}: Fill in the missing keywords...
 keywords = [
+    {% for keyword in package_keywords.split(",") if keyword.strip() %}"{{ keyword.strip() }}", {% endfor %}
     "command-line", "cli", "package", "metadata", "pypi", "python",
     "template", "copier", "scaffold", "boilerplate", "uv", "hatch",
     "tox", "pytest", "ruff", "mypy", "basedpyright",


### PR DESCRIPTION
## Summary

Adds a free-form `package_keywords` Copier prompt so generated projects can supply their own project-specific PyPI keywords at scaffold time, replacing the manual `TODO` marker in `pyproject.toml`.

- **`copier.yml`** — new `package_keywords` variable (`str`, default `""`).
- **`template/pyproject.toml.jinja`** — splits the input on commas, trims whitespace, skips empties, and prepends the result to the `keywords` list. The template's base, tooling, and enabled-component keywords are still appended automatically. Removes the keywords `TODO` marker.
- **`.example-input.yml`** — sets `package_keywords: "example, demo"` to exercise the path.
- **`README.md` / `CLAUDE.md`** — document the new variable.

The classifiers `TODO` is intentionally left untouched for now.

## Test plan

- [x] `copier copy` renders with input → keywords lead with `example`, `demo`
- [x] `copier copy` with empty `package_keywords` → list unchanged
- [x] Both rendered `pyproject.toml` files parse as valid TOML
- [x] Regenerated committed `example/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)